### PR TITLE
TRITON-2142 Add postgresql notification support to Moray

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.0
+
+* [TRITON-2142](https://jira.joyent.us/browse/TRITON-2142) add listen() and
+  notify() APIs to allow use of PostgreSQL listen/notify features.
+
 ## v4.0.2
 
 * Add "files" to package.json to avoid unnecessary voluminous junk in the

--- a/bin/moraylisten
+++ b/bin/moraylisten
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// -*- mode: js -*-
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+var cmdutil = require('cmdutil');
+var moray = require('../lib');
+var moraycli = require('../lib/cmd');
+
+var channel, parser, client, clientOptions;
+
+cmdutil.configure({
+    'usageMessage': 'listen for Moray notifications',
+    'synopses': [ moraycli.commonUsage + ' CHANNEL']
+});
+
+clientOptions = {};
+parser = moraycli.parseCliOptions({
+    'argv': process.argv,
+    'env': process.env,
+    'errstream': process.stderr,
+    'extraOptStr': 'c',
+    'clientOptions': clientOptions,
+    'onUsage': cmdutil.usage,
+    'onOption': function (option) {
+        switch (option.option) {
+        default:
+            cmdutil.usage();
+            break;
+        }
+    }
+});
+
+if (parser.optind() >= process.argv.length)
+    cmdutil.usage('missing required argument: "channel"');
+channel = process.argv[parser.optind()];
+
+client = moray.createClient(clientOptions);
+client.on('error', cmdutil.fail);
+client.on('connect', function onConnect() {
+    process.stderr.write('Connected - listening for "' + channel +
+        '" notifications\n');
+
+    process.on('SIGINT', function _catchSigInt() {
+        process.stderr.write('Caught interrupt signal - shutting down\n');
+        moraycli.cliFinish(cmdutil, client);
+        listener.unlisten(function _unlistenCb() {
+            client.close();
+        });
+    });
+
+    var listener = client.listen(channel);
+
+    listener.on('readable', function _readable() {
+        var notification = listener.read();
+        while (notification) {
+            console.log(notification.payload);
+            notification = listener.read();
+        }
+    });
+
+    listener.once('error', cmdutil.fail);
+});

--- a/bin/moraynotify
+++ b/bin/moraynotify
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// -*- mode: js -*-
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+var cmdutil = require('cmdutil');
+var moray = require('../lib');
+var moraycli = require('../lib/cmd');
+
+var channel, client, clientOptions, parser, payload;
+
+cmdutil.configure({
+    'usageMessage': 'send a Moray notification',
+    'synopses': [ moraycli.commonUsage + ' CHANNEL PAYLOAD']
+});
+
+clientOptions = {};
+parser = moraycli.parseCliOptions({
+    'argv': process.argv,
+    'env': process.env,
+    'errstream': process.stderr,
+    'extraOptStr': 'c',
+    'clientOptions': clientOptions,
+    'onUsage': cmdutil.usage,
+    'onOption': function (option) {
+        switch (option.option) {
+        default:
+            cmdutil.usage();
+            break;
+        }
+    }
+});
+
+if (parser.optind() >= process.argv.length)
+    cmdutil.usage('missing required argument: "channel"');
+channel = process.argv[parser.optind()];
+
+if (parser.optind()+1 >= process.argv.length)
+    cmdutil.usage('missing required argument: "payload"');
+payload = process.argv[parser.optind()+1];
+
+client = moray.createClient(clientOptions);
+
+client.on('error', cmdutil.fail);
+
+client.on('connect', function onConnect() {
+    client.notify(channel, payload, function _onNotifyComplete(err) {
+        if (err) {
+            cmdutil.fail(err);
+        }
+
+        moraycli.cliFinish(cmdutil, client);
+        client.close();
+    });
+});

--- a/docs/man/man1/moraylisten.md
+++ b/docs/man/man1/moraylisten.md
@@ -1,0 +1,56 @@
+# moraylisten 1 "June 2020" Moray "Moray Client Tools"
+
+## NAME
+
+moraylisten - listen for Moray notifications on the given channel
+
+## SYNOPSIS
+
+`moraylisten [COMMON_OPTIONS] CHANNEL`
+
+## DESCRIPTION
+
+Listens for notifications on `CHANNEL` and outputs the notification payload
+(string) to stdout. This is a long process and can be stopped using a SIGINT
+interrupt (Ctrl-C).
+
+## ENVIRONMENT
+
+See `moray(1)` for information about the `LOG_LEVEL`, `MORAY_SERVICE`, and
+`MORAY_URL` environment variables.
+
+## EXAMPLES
+
+Listen for status notifications, the payload is an arbitrary string:
+
+    $ moraylisten status
+    Connected - listening for notifications
+    online 2020-06-22T23:17:36.689Z
+    offline 2020-06-22T23:19:16.164Z
+    online 2020-06-22T23:19:21.762Z
+    offline 2020-06-22T23:50:00.000Z
+    ^C Caught interrupt signal - shutting down
+
+Listen for workflow notifications, the payload in this case is an encoded JSON
+string:
+
+    $ moraylisten workflow_job_status_changed | json -ga
+    Connected - listening for notifications
+    {
+        "prevExecution": null,
+        "lastResult": {
+            "result": "OK",
+            "error": "",
+            "name": "cnapi.release_vm_ticket",
+            "started_at": "2020-06-22T20:31:27.853Z",
+            "finished_at": "2020-06-22T20:31:28.049Z"
+        },
+        "name": "start-7.0.8",
+        "execution": "succeeded",
+        "uuid": "9093c11f-7034-4df4-9339-5f167fe37e9e"
+    }
+    ^C Caught interrupt signal - shutting down
+
+## SEE ALSO
+
+`moray(1)`, `moraynotify(1)`

--- a/docs/man/man1/moraynotify.md
+++ b/docs/man/man1/moraynotify.md
@@ -1,0 +1,35 @@
+# moraynotify 1 "June 2020" Moray "Moray Client Tools"
+
+## NAME
+
+moraynotify - send a Moray notification on the given channel
+
+## SYNOPSIS
+
+`moraynotify [COMMON_OPTIONS] CHANNEL PAYLOAD`
+
+## DESCRIPTION
+
+Sends the notification payload to `CHANNEL`.
+
+Note that the maximum length of the payload is restricted to 8000 bytes.
+
+## ENVIRONMENT
+
+See `moray(1)` for information about the `LOG_LEVEL`, `MORAY_SERVICE`, and
+`MORAY_URL` environment variables.
+
+## EXAMPLES
+
+Notify a status notification, the payload is an arbitrary string:
+
+    $ moraynotify status "online 2020-06-22T23:17:36.689Z"
+    $ moraynotify status "offline 2020-06-22T23:23:00.000Z"
+
+Notify a json encoded payload:
+
+    $ moraynotify mychannel '{"name": "data", "item": {"length": 2}}'
+
+## SEE ALSO
+
+`moray(1)`, `moraylisten(1)`

--- a/lib/client.js
+++ b/lib/client.js
@@ -1040,6 +1040,61 @@ MorayClient.prototype.sql = function _sql(stmt, vals, opts) {
 };
 
 
+/**
+ * Listens on the given channel for Postgresql notifications.
+ *
+ * @param {String} channel - Notification channel to listen on
+ * @param {Object} opts    - Request Options
+ * @return {EventEmitter} - listen for 'notification', 'end' and 'error'
+ */
+MorayClient.prototype.listen = function _listen(channel, opts) {
+    var rv;
+
+    opts = opts || {};
+
+    assert.string(channel, 'channel');
+    assert.object(opts, 'opts');
+
+    var rpcctx = this.ctxCreateForEmitter();
+    if (rpcctx) {
+        rv = meta.listen(rpcctx, channel, opts);
+        this.releaseWhenDone(rpcctx, rv);
+        return (rv);
+    }
+
+    return (emitUnavailable());
+};
+
+
+/**
+ * Notify this channel with this payload.
+ *
+ * @param {String} channel - Notification channel to listen on
+ * @param {String} payload - Notification payload to send
+ * @param {Object} opts    - Request Options
+ * @param {Function} cb    - cb(err)
+ */
+MorayClient.prototype.notify = function _notify(channel, payload, opts, cb) {
+    assert.string(channel, 'channel');
+    assert.string(payload, 'payload');
+
+    if (typeof (opts) === 'function') {
+        cb = opts;
+        opts = {};
+    }
+
+    assert.func(cb, 'cb');
+
+    var rpcctx = this.ctxCreateForCallback(cb);
+    if (rpcctx) {
+        meta.notify(rpcctx, channel, payload, opts,
+            this.makeReleaseCb(rpcctx, cb));
+    } else {
+        cb(emitUnavailable());
+    }
+};
+
+
 /*
  * A MorayRpcContext is a per-request handle that refers back to the Moray
  * client and the underlying connection.  This object is provided to RPC

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -17,8 +17,8 @@
 
 var assert = require('assert-plus');
 var uuidv4 = require('uuid/v4');
-var jsprim = require('jsprim');
 var events = require('events');
+var stream = require('stream');
 var VError = require('verror');
 
 var rpc = require('./rpc');
@@ -186,9 +186,81 @@ function sql(rpcctx, statement, values, options) {
 }
 
 
+function listen(rpcctx, channel, options) {
+    var opts, log, req, res;
+
+    assert.object(rpcctx, 'rpcctx');
+    assert.string(channel, 'channel');
+    assert.object(options, 'options');
+    assert.optionalNumber(options.timeout, 'options.timeout');
+
+    opts = {
+        req_id: options.req_id || uuidv4(),
+        timeout: options.timeout
+    };
+    log = rpc.childLogger(rpcctx, opts);
+
+    res = new stream.PassThrough({objectMode: true});
+    res.req_id = opts.req_id;
+
+    /*
+     * We specify ignoreNullValues because electric-moray sends spurious
+     * trailing null values from successful sql() commands.  These are not
+     * generally allowed, but we have to maintain compatibility with broken
+     * servers.
+     */
+    req = rpc.rpcCommon({
+        'rpcctx': rpcctx,
+        'rpcmethod': 'listen',
+        'rpcargs': [ channel, opts ],
+        'ignoreNullValues': true,
+        'log': log
+    }, function (err) {
+        if (err) {
+            res.emit('error', err);
+        } else {
+            res.emit('end');
+        }
+
+        res.emit('_moray_internal_rpc_done');
+    });
+
+    req.pipe(res);
+
+    // Add unlisten hook so clients can easily unlisten from the channel.
+    res.unlisten = function _listenUnlisten(cb) {
+        rpc.rpcCommonNoData({
+            'rpcctx': rpcctx,
+            'rpcmethod': 'unlisten',
+            'rpcargs': [ opts.req_id, opts ],
+            'log': log,
+            'timeout': opts.hasOwnProperty('timeout') ? opts.timeout : 2000
+        }, cb);
+    };
+
+    return (res);
+}
+
+function notify(rpcctx, channel, payload, options, callback) {
+    assert.object(rpcctx, 'rpcctx');
+    assert.string(channel, 'channel');
+    assert.string(payload, 'payload');
+    assert.object(options, 'options');
+    assert.optionalNumber(options.timeout, 'options.timeout');
+    assert.func(callback, 'callback');
+
+    var statement = 'select pg_notify($1, $2)';
+    var res = sql(rpcctx, statement, [channel, payload], options);
+
+    res.once('error', callback);
+    res.once('end', callback);
+}
+
 ///--- Exports
 
 module.exports = {
+    listen: listen,
+    notify: notify,
     ping: ping,
     sql: sql,
     versionInternal: versionInternal

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "moray",
     "description": "Moray client library",
-    "version": "4.0.2",
+    "version": "4.1.0",
     "author": "Joyent (joyent.com)",
     "keywords": [
         "moray"


### PR DESCRIPTION
Moray client support for listen/notify. This includes two new moray CLI tools - `moraylisten` and `moraynotify`.

Example listen:
```
$ moraylisten -h moray.dingo.local "status"
Connected - listening for "status" notifications
hello there you
hello there again
^CCaught interrupt signal - shutting down
```

Example notify:
```
$ moraynotify -h moray.dingo.local status "hello there you"
$ moraynotify -h moray.dingo.local status "hello there again"
```
